### PR TITLE
feat:フロントエンドの基本ルーティングの作成

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,8 @@ import RootLayout from './components/layouts/RootLayout'
 import Home from './pages/Home'
 import About from './pages/About'
 import Info from './pages/Info/Info'
+import Login from './pages/Login'
+import Signup from './pages/Signup'
 
 export default function App() {
   return (
@@ -11,6 +13,8 @@ export default function App() {
         <Route index element={<Home />} />
         <Route path="about" element={<About />} />
         <Route path="info" element={<Info />} />
+        <Route path="login" element={<Login />} />
+        <Route path="signup" element={<Signup />} />
       </Route>
     </Routes>
   )

--- a/web/src/components/layouts/RootLayout.tsx
+++ b/web/src/components/layouts/RootLayout.tsx
@@ -4,21 +4,23 @@ export default function RootLayout() {
   return (
     <div className="min-h-screen flex flex-col">
       <header className="bg-blue-600 text-white p-4">
-        <nav className="flex gap-6 items-center">
-          <span className="font-bold text-lg">jyogi-OAuth</span>
-          <Link to="/" className="hover:underline">Home</Link>
-          <Link to="/about" className="hover:underline">About</Link>
-          <Link to="/info" className="hover:underline">Info</Link>
+        <nav className="flex items-center">
+          <span className="font-bold text-lg mr-6">jyogi-OAuth</span>
+          <div className="flex gap-6">
+            <Link to="/" className="hover:underline">Home</Link>
+            <Link to="/about" className="hover:underline">About</Link>
+            <Link to="/info" className="hover:underline">Info</Link>
+          </div>
+          <div className="ml-auto flex gap-4">
+            <Link to="/login" className="hover:underline">ログイン</Link>
+            <Link to="/signup" className="hover:underline">新規登録</Link>
+          </div>
         </nav>
       </header>
 
       <main className="flex-1 p-6">
         <Outlet />
       </main>
-
-      <footer className="bg-gray-100 text-center p-4 text-sm text-gray-500">
-        © 2025 jyogi-OAuth
-      </footer>
     </div>
   )
 }

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,8 +1,23 @@
+import { Link } from 'react-router-dom'
+
 export default function Home() {
   return (
-    <div>
-      <h1 className="text-2xl font-bold mb-2">ホーム</h1>
-      <p>ようこそ jyogi-OAuth へ</p>
+    <div className="max-w-lg mx-auto mt-16 text-center">
+      <h1 className="text-4xl font-bold mb-4">jyogi-OAuth</h1>
+      <div className="flex justify-center gap-4">
+        <Link
+          to="/login"
+          className="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700"
+        >
+          ログイン
+        </Link>
+        <Link
+          to="/signup"
+          className="border border-blue-600 text-blue-600 px-6 py-2 rounded hover:bg-blue-50"
+        >
+          新規登録
+        </Link>
+      </div>
     </div>
   )
 }

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,0 +1,47 @@
+import { Link, useNavigate } from 'react-router-dom'
+
+export default function Login() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="bg-white p-8 rounded-lg shadow w-full max-w-sm">
+        <h1 className="text-2xl font-bold mb-6 text-center">ログイン</h1>
+
+        <form onSubmit={(e) => { e.preventDefault(); navigate('/') }} className="flex flex-col gap-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">ユーザー名</label>
+            <input
+              type="text"
+              className="w-full border rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="username"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">パスワード</label>
+            <input
+              type="password"
+              className="w-full border rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="••••••••"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="bg-blue-600 text-white rounded-md py-2 hover:bg-blue-700 transition-colors"
+          >
+            ログイン
+          </button>
+        </form>
+
+        <p className="mt-4 text-sm text-center text-gray-600">
+          アカウントをお持ちでない方は{' '}
+          <Link to="/signup" className="text-blue-600 hover:underline">
+            新規登録
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/Signup.tsx
+++ b/web/src/pages/Signup.tsx
@@ -1,0 +1,47 @@
+import { Link, useNavigate } from 'react-router-dom'
+
+export default function Signup() {
+  const navigate = useNavigate()
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="bg-white p-8 rounded-lg shadow w-full max-w-sm">
+        <h1 className="text-2xl font-bold mb-6 text-center">新規登録</h1>
+
+        <form onSubmit={(e) => { e.preventDefault(); navigate('/') }} className="flex flex-col gap-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">ユーザー名</label>
+            <input
+              type="text"
+              className="w-full border rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="username"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">パスワード</label>
+            <input
+              type="password"
+              className="w-full border rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="••••••••"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="bg-blue-600 text-white rounded-md py-2 hover:bg-blue-700 transition-colors"
+          >
+            登録
+          </button>
+        </form>
+
+        <p className="mt-4 text-sm text-center text-gray-600">
+          すでにアカウントをお持ちの方は{' '}
+          <Link to="/login" className="text-blue-600 hover:underline">
+            ログイン
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION

## Overview / 概要
[JP] OAuth サービスの入口となる /(ホームに遷移)・Login・Signup ページを追加した。

---

## Type / 種類
<!-- 該当するものを残す -->
- Feature
---

## Changes / 変更内容  
[JP] 主な変更点
- web/src/pages/Home.tsx — サービス概要・Login/Signup への導線ボタンを追加
- web/src/pages/Login.tsx — 新規作成（ユーザー名・パスワード入力、送信で / に遷移）
- web/src/pages/Signup.tsx — 新規作成（ユーザー名・パスワード入力、送信で / に遷移）
- web/src/App.tsx — /login・/signup ルートを追加
- web/src/components/layouts/RootLayout.tsx — ナビゲーションに Login・Signup リンクを追加

---

## Motivation / Purpose / 目的
[JP]  OAuth サービスの利用者が最初に訪れるページを整備するため。
---
## スクリーンショット
 ホーム画面
<img width="1915" height="918" alt="スクリーンショット 2026-03-16 162206" src="https://github.com/user-attachments/assets/1ee0593d-5d8b-42bb-8700-8162ea71bc9f" />
新規登録画面
<img width="1919" height="956" alt="スクリーンショット 2026-03-16 162337" src="https://github.com/user-attachments/assets/8969ffb7-48bf-454a-b236-0b0cb1fa35d9" />
ログイン画面
<img width="1913" height="869" alt="スクリーンショット 2026-03-16 162402" src="https://github.com/user-attachments/assets/172b1fd9-8d5d-47ea-93f1-094713c0359b" />

---
## How to Test / 動作確認方法
[JP] 動作確認手順

1.  cd web
2.  npm run dev
3.  /で遷移するor登録ボタンを押す

---

## Related Issue / 関連 Issue
- Closes #9

---

## Additional Notes / 補足
[JP] 必要に応じた補足・スクショなど
現時点ではフォームの UI のみです。