### PR TITLE
[Feature][API] OAuth API のルート構造を `/api/v1` 配下に再編

### DIFF
--- a/api/src/adapter/http/handlers/admin.rs
+++ b/api/src/adapter/http/handlers/admin.rs
@@ -1,0 +1,13 @@
+use axum::http::StatusCode;
+
+pub async fn list_users() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}
+
+pub async fn list_clients() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}
+
+pub async fn list_audit_logs() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}

--- a/api/src/adapter/http/handlers/auth.rs
+++ b/api/src/adapter/http/handlers/auth.rs
@@ -1,0 +1,13 @@
+use axum::http::StatusCode;
+
+pub async fn me() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}
+
+pub async fn logout() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}
+
+pub async fn refresh() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}

--- a/api/src/adapter/http/handlers/clients.rs
+++ b/api/src/adapter/http/handlers/clients.rs
@@ -1,0 +1,21 @@
+use axum::http::StatusCode;
+
+pub async fn list_clients() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}
+
+pub async fn create_client() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}
+
+pub async fn get_client() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}
+
+pub async fn update_client() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}
+
+pub async fn delete_client() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}

--- a/api/src/adapter/http/handlers/mod.rs
+++ b/api/src/adapter/http/handlers/mod.rs
@@ -1,1 +1,6 @@
+pub mod admin;
+pub mod auth;
+pub mod clients;
 pub mod health;
+pub mod oauth;
+pub mod users;

--- a/api/src/adapter/http/handlers/oauth.rs
+++ b/api/src/adapter/http/handlers/oauth.rs
@@ -1,0 +1,17 @@
+use axum::http::StatusCode;
+
+pub async fn authorize() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}
+
+pub async fn token() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}
+
+pub async fn revoke() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}
+
+pub async fn userinfo() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}

--- a/api/src/adapter/http/handlers/users.rs
+++ b/api/src/adapter/http/handlers/users.rs
@@ -1,0 +1,5 @@
+use axum::http::StatusCode;
+
+pub async fn me() -> (StatusCode, &'static str) {
+    (StatusCode::NOT_IMPLEMENTED, "not implemented")
+}

--- a/api/src/adapter/http/routes/admin.rs
+++ b/api/src/adapter/http/routes/admin.rs
@@ -1,0 +1,13 @@
+use axum::{Router, routing::get};
+
+use crate::{
+    adapter::http::handlers::admin,
+    state::AppState,
+};
+
+pub fn routes() -> Router<AppState> {
+    Router::<AppState>::new()
+        .route("/admin/users", get(admin::list_users))
+        .route("/admin/clients", get(admin::list_clients))
+        .route("/admin/audit-logs", get(admin::list_audit_logs))
+}

--- a/api/src/adapter/http/routes/auth.rs
+++ b/api/src/adapter/http/routes/auth.rs
@@ -1,0 +1,13 @@
+use axum::{Router, routing::{get, post}};
+
+use crate::{
+    adapter::http::handlers::auth,
+    state::AppState,
+};
+
+pub fn routes() -> Router<AppState> {
+    Router::<AppState>::new()
+        .route("/auth/me", get(auth::me))
+        .route("/auth/logout", post(auth::logout))
+        .route("/auth/refresh", post(auth::refresh))
+}

--- a/api/src/adapter/http/routes/clients.rs
+++ b/api/src/adapter/http/routes/clients.rs
@@ -1,0 +1,20 @@
+use axum::{Router, routing::get};
+
+use crate::{
+    adapter::http::handlers::clients,
+    state::AppState,
+};
+
+pub fn routes() -> Router<AppState> {
+    Router::<AppState>::new()
+        .route(
+            "/clients",
+            get(clients::list_clients).post(clients::create_client),
+        )
+        .route(
+            "/clients/{client_id}",
+            get(clients::get_client)
+                .patch(clients::update_client)
+                .delete(clients::delete_client),
+        )
+}

--- a/api/src/adapter/http/routes/mod.rs
+++ b/api/src/adapter/http/routes/mod.rs
@@ -1,1 +1,23 @@
+pub mod admin;
+pub mod auth;
+pub mod clients;
 pub mod health;
+pub mod oauth;
+pub mod users;
+
+use axum::Router;
+
+use crate::state::AppState;
+
+pub fn routes() -> Router<AppState> {
+    Router::<AppState>::new().nest(
+        "/api/v1",
+        Router::<AppState>::new()
+            .merge(health::routes())
+            .merge(auth::routes())
+            .merge(oauth::routes())
+            .merge(clients::routes())
+            .merge(users::routes())
+            .merge(admin::routes()),
+    )
+}

--- a/api/src/adapter/http/routes/oauth.rs
+++ b/api/src/adapter/http/routes/oauth.rs
@@ -1,0 +1,14 @@
+use axum::{Router, routing::{get, post}};
+
+use crate::{
+    adapter::http::handlers::oauth,
+    state::AppState,
+};
+
+pub fn routes() -> Router<AppState> {
+    Router::<AppState>::new()
+        .route("/oauth/authorize", get(oauth::authorize))
+        .route("/oauth/token", post(oauth::token))
+        .route("/oauth/revoke", post(oauth::revoke))
+        .route("/oauth/userinfo", get(oauth::userinfo))
+}

--- a/api/src/adapter/http/routes/users.rs
+++ b/api/src/adapter/http/routes/users.rs
@@ -1,0 +1,10 @@
+use axum::{Router, routing::get};
+
+use crate::{
+    adapter::http::handlers::users,
+    state::AppState,
+};
+
+pub fn routes() -> Router<AppState> {
+    Router::<AppState>::new().route("/users/me", get(users::me))
+}

--- a/api/src/app.rs
+++ b/api/src/app.rs
@@ -1,12 +1,12 @@
 use axum::Router;
 
 use crate::{
-    adapter::http::routes::health,
+    adapter::http::routes,
     state::AppState,
 };
 
 pub fn create_app(state: AppState) -> Router {
     Router::<AppState>::new()
-        .merge(health::routes())
+        .merge(routes::routes())
         .with_state(state)
 }

--- a/api/tests/health.rs
+++ b/api/tests/health.rs
@@ -17,13 +17,38 @@ async fn health_returns_200() -> Result<(), Box<dyn std::error::Error>> {
     let response = app
         .oneshot(
             Request::builder()
-                .uri("/health")
+                .uri("/api/v1/health")
                 .method("GET")
                 .body(Body::empty())?,
         )
         .await?;
 
     assert_eq!(response.status(), StatusCode::OK);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn legacy_health_returns_404() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config {
+        app_host: "127.0.0.1".to_string(),
+        app_port: 3000,
+        rust_log: "info".to_string(),
+    };
+
+    let state = AppState::new(config);
+    let app = app::create_app(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .method("GET")
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
     Ok(())
 }


### PR DESCRIPTION
## Title / タイトル
[Feature][API] OAuth API のルート構造を `/api/v1` 配下に再編
<!-- Example: [BUG] Fix crash on startup -->

---

## Overview / 概要
[EN] Brief summary of what this PR does  
[JP] この PR が行う変更の概要を簡潔に記載
OAuthサービス向けにバージョニング付きAPIルーティング構造を導入し、主要責務の route/handler skeleton を追加
---

## Type / 種類
<!-- 該当するものを残す -->
- Feature
- Refactoring

---

## Changes / 変更内容
[EN] List key changes  
[JP] 主な変更点

- `/api/v1` prefix を導入し、ルートを集約
- `auth / oauth / clients / users / admin` の route module を追加
- 上記に対応する handler skeleton を追加（業務ロジックは未実装）
- `health` を `/api/v1/health` へ移行（旧 `/health` は廃止）
- テスト更新（`/api/v1/health` が 200、旧 `/health` が 404）
- Axum 0.8 対応として `"/clients/:client_id"` → `"/clients/{client_id}"` に修正      

---

## Motivation / Purpose / 目的
[EN] Why this change is needed  
[JP] なぜこの変更が必要なのか
現状は health のみであり、OAuth実装を進めるために責務ごとの明確で拡張しやすいルート構造が必要だったため
---

## How to Test / 動作確認方法
[EN] Steps to verify the behavior  
[JP] 動作確認手順

1. `cd api`
2. `cargo test`
3. `cargo clippy --all-targets --all-features`

---

## Related Issue / 関連 Issue
- Closes #8 

---

## Additional Notes / 補足
[EN] Optional notes, screenshots, etc.  
[JP] 必要に応じた補足・スクショなど
本PRはルーティング構造と skeleton の整備が対象
DB連携や業務ロジックは後続 Issueで実装