### PR TITLE
feat:フロントエンドの基本ルーティングの作成

### DIFF
--- a/migrations/0000_extensions.sql
+++ b/migrations/0000_extensions.sql
@@ -1,0 +1,13 @@
+-- extensions & shared functions
+-- downは通常不要（本番でextension削除しないため）
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- 共通: updated_at 自動更新
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/0001_users.down.sql
+++ b/migrations/0001_users.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS users;
+DROP TYPE IF EXISTS user_status;

--- a/migrations/0001_users.up.sql
+++ b/migrations/0001_users.up.sql
@@ -1,0 +1,32 @@
+-- user_status enum
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'user_status') THEN
+        CREATE TYPE user_status AS ENUM (
+            'active',
+            'inactive',
+            'suspended',
+            'deleted'
+        );
+    END IF;
+END$$;
+
+-- users
+CREATE TABLE IF NOT EXISTS users (
+    id BIGSERIAL PRIMARY KEY,
+    uuid UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+
+    status user_status NOT NULL DEFAULT 'active',
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_status
+ON users(status);
+
+CREATE TRIGGER trg_users_updated_at
+BEFORE UPDATE ON users
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();

--- a/migrations/0002_user_identities.down.sql
+++ b/migrations/0002_user_identities.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS user_identities;

--- a/migrations/0002_user_identities.up.sql
+++ b/migrations/0002_user_identities.up.sql
@@ -1,0 +1,41 @@
+-- user_identities
+CREATE TABLE IF NOT EXISTS user_identities (
+    id BIGSERIAL PRIMARY KEY,
+
+    user_id BIGINT NOT NULL
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+
+    type VARCHAR(50) NOT NULL,
+
+    identifier VARCHAR(255) NOT NULL,
+    normalized_identifier VARCHAR(255) NOT NULL,
+
+    is_primary BOOLEAN NOT NULL DEFAULT FALSE,
+
+    last_used_at TIMESTAMPTZ,
+    verified_at TIMESTAMPTZ,
+    revoked_at TIMESTAMPTZ,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CHECK (char_length(identifier) > 0),
+    CHECK (char_length(normalized_identifier) > 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_user_identities_active_identifier
+ON user_identities(type, normalized_identifier)
+WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_user_identities_user_id
+ON user_identities(user_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_user_identities_primary
+ON user_identities(user_id)
+WHERE is_primary = TRUE AND revoked_at IS NULL;
+
+CREATE TRIGGER trg_user_identities_updated_at
+BEFORE UPDATE ON user_identities
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();

--- a/migrations/0003_user_credentials.down.sql
+++ b/migrations/0003_user_credentials.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS user_credentials;

--- a/migrations/0003_user_credentials.up.sql
+++ b/migrations/0003_user_credentials.up.sql
@@ -1,0 +1,43 @@
+-- user_credentials
+-- 認証手段（password / totp / webauthn / oauth等）
+
+CREATE TABLE IF NOT EXISTS user_credentials (
+    id BIGSERIAL PRIMARY KEY,
+
+    user_id BIGINT NOT NULL
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+
+    type VARCHAR(50) NOT NULL,
+    -- password / totp / webauthn / oauth_refresh など
+
+    secret_hash TEXT NOT NULL,
+    -- パスワード・トークン・鍵など（必ずハッシュ）
+
+    secret_meta JSONB,
+    -- 公開鍵・設定情報など
+
+    is_primary BOOLEAN NOT NULL DEFAULT FALSE,
+
+    last_used_at TIMESTAMPTZ,
+    verified_at TIMESTAMPTZ,
+    revoked_at TIMESTAMPTZ,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_credentials_user_id
+ON user_credentials(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_credentials_type
+ON user_credentials(type);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_user_credentials_primary
+ON user_credentials(user_id)
+WHERE is_primary = TRUE AND revoked_at IS NULL;
+
+CREATE TRIGGER trg_user_credentials_updated_at
+BEFORE UPDATE ON user_credentials
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();

--- a/migrations/0004_user_profile.down.sql
+++ b/migrations/0004_user_profile.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS user_profile;

--- a/migrations/0004_user_profile.up.sql
+++ b/migrations/0004_user_profile.up.sql
@@ -1,0 +1,26 @@
+-- user_profile（1:1）
+
+CREATE TABLE IF NOT EXISTS user_profile (
+    user_id BIGINT PRIMARY KEY
+        REFERENCES users(id)
+        ON DELETE CASCADE,
+
+    display_name VARCHAR(255) NOT NULL,
+    avatar_url VARCHAR(512),
+
+    tagline VARCHAR(100),
+    bio TEXT,
+
+    locale VARCHAR(50),
+    timezone VARCHAR(50),
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CHECK (tagline IS NULL OR char_length(tagline) <= 100)
+);
+
+CREATE TRIGGER trg_user_profile_updated_at
+BEFORE UPDATE ON user_profile
+FOR EACH ROW
+EXECUTE FUNCTION set_updated_at();


### PR DESCRIPTION
## Title / タイトル
[Feature] ユーザー認証・プロフィール基盤スキーマの追加

---

## Overview / 概要
SQLx migration を用いて、ユーザー管理・認証・プロフィールおよびタグ機能のコアスキーマを追加

---

## Type / 種類
- Feature

---

## Changes / 変更内容
- users テーブルの追加（UUID・ステータス管理）
- user_identities の追加（email / username / OAuth などのログイン識別子）
- user_credentials の追加（password / WebAuthn などの認証手段）
- user_profile の追加（tagline を含むプロフィール情報）
- 共通関数 set_updated_at と extension（pgcrypto）の追加

---

## Motivation / Purpose / 目的
複数の認証方式（password / OAuth / WebAuthn）に対応できる拡張性の高い認証基盤と、柔軟なプロフィール機能を構築するため

---

## How to Test / 動作確認方法
[EN] Steps to verify the behavior  
[JP] 動作確認手順

1.  SQLx で migration を実行
2. 各テーブルが正しく作成されていることを確認
3. サンプルデータ（users / user_identities / user_credentials）を投入
4. email または username + password でログイン可能であることを確認
5. user_profile が正しく取得・更新できることを確認 

---

## Related Issue / 関連 Issue
- Closes #16 

---

## Additional Notes / 補足
